### PR TITLE
gor-purdue: correct misspelling word(**kwargs) in sc2_comm.py

### DIFF
--- a/src/core/sc2_comm.py
+++ b/src/core/sc2_comm.py
@@ -31,7 +31,7 @@ class sc2(object):
         if self.is_connected:
             self.conn.close()
 
-    def send(self, **kargs):
+    def send(self, **kwargs):
         request = sc_pb.Request(**kwargs)
         request_str = request.SerializeToString()
         if self.is_connected:


### PR DESCRIPTION
I found that sc2_comm.py file has misspelled word.

line 34: **kargs->**kwargs

Now it's working well.